### PR TITLE
fix(github-action): fetch tags in ifReleaseCommit to not re-release already released commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ tmp
 # Staff
 .vite*
 .codex
+.claude
 .agents
 skills-lock.json

--- a/packages/github-action/package.json
+++ b/packages/github-action/package.json
@@ -49,8 +49,9 @@
     "postpublish": "pnpm clear:package",
     "build": "tsgo -p tsconfig.build.json",
     "lint": "oxlint",
+    "test:unit": "vitest run --coverage",
     "test:types": "tsgo --noEmit",
-    "test": "run -p lint test:types"
+    "test": "run -p lint test:unit test:types"
   },
   "dependencies": {
     "@actions/core": "^3.0.1",
@@ -60,6 +61,7 @@
     "@simple-release/github": "workspace:^"
   },
   "devDependencies": {
-    "@simple-release/pnpm": "workspace:^"
+    "@simple-release/pnpm": "workspace:^",
+    "test": "workspace:^"
   }
 }

--- a/packages/github-action/src/conditions.spec.ts
+++ b/packages/github-action/src/conditions.spec.ts
@@ -1,0 +1,126 @@
+import { join } from 'path'
+import fs from 'fs/promises'
+import {
+  describe,
+  it,
+  expect
+} from 'vitest'
+import type { getOctokit } from '@actions/github'
+import { PackageJsonProject } from '@simple-release/core'
+import {
+  createDirectory,
+  packageJsonProject
+} from 'test'
+import { ReleaserGithubAction } from './releaser.js'
+import { ifReleaseCommit } from './conditions.js'
+
+const octokit = {} as ReturnType<typeof getOctokit>
+
+describe('github-action', () => {
+  describe('conditions', () => {
+    describe('ifReleaseCommit', () => {
+      it('should detect release commit in a shallow clone', async () => {
+        const { cwd, run } = await packageJsonProject(
+          {
+            name: 'unreleased-commit-project'
+          },
+          {
+            postReleaseCommits: false
+          }
+        )
+
+        await run([
+          ({ cwd }) => fs.writeFile(
+            join(cwd, 'package.json'),
+            JSON.stringify({
+              name: 'unreleased-commit-project',
+              version: '2.1.0'
+            })
+          ),
+          ({ git }) => git.add('package.json'),
+          ({ git }) => git.commit({
+            message: 'chore(release): 2.1.0'
+          })
+        ])
+
+        const cloneCwd = await createDirectory('unreleased-commit-clone')
+        const project = new PackageJsonProject({
+          path: join(cloneCwd, 'package.json')
+        })
+        const releaser = new ReleaserGithubAction({
+          project,
+          octokit,
+          silent: true
+        })
+
+        // Clone the repository like actions/checkout does by default: depth 1 and no tags.
+        await project.gitClient.exec('clone', '--depth', '1', '--no-tags', `file://${cwd}`, '.')
+
+        expect(await ifReleaseCommit(releaser)).toBe(true)
+      })
+
+      it('should not treat already released commit as a new release', async () => {
+        const { cwd, run } = await packageJsonProject(
+          {
+            name: 'released-commit-project'
+          },
+          {
+            postReleaseCommits: false
+          }
+        )
+
+        await run([
+          ({ cwd }) => fs.writeFile(
+            join(cwd, 'package.json'),
+            JSON.stringify({
+              name: 'released-commit-project',
+              version: '2.1.0'
+            })
+          ),
+          ({ git }) => git.add('package.json'),
+          ({ git }) => git.commit({
+            message: 'chore(release): 2.1.0'
+          }),
+          ({ git }) => git.tag({
+            name: 'v2.1.0'
+          })
+        ])
+
+        const cloneCwd = await createDirectory('released-commit-clone')
+        const project = new PackageJsonProject({
+          path: join(cloneCwd, 'package.json')
+        })
+        const releaser = new ReleaserGithubAction({
+          project,
+          octokit,
+          silent: true
+        })
+
+        await project.gitClient.exec('clone', '--depth', '1', '--no-tags', `file://${cwd}`, '.')
+
+        expect(await ifReleaseCommit(releaser)).toBe(false)
+      })
+
+      it('should not fetch tags for a non-release commit', async () => {
+        const { cwd } = await packageJsonProject({
+          name: 'non-release-commit-project'
+        })
+        const cloneCwd = await createDirectory('non-release-commit-clone')
+        const project = new PackageJsonProject({
+          path: join(cloneCwd, 'package.json')
+        })
+        const releaser = new ReleaserGithubAction({
+          project,
+          octokit,
+          silent: true
+        })
+
+        await project.gitClient.exec('clone', '--depth', '1', '--no-tags', `file://${cwd}`, '.')
+        // Break the remote to ensure no fetch is attempted before the commit message check.
+        await project.gitClient.exec('remote', 'set-url', 'origin', 'file:///nonexistent')
+
+        expect(await ifReleaseCommit(releaser)).toBe(false)
+      })
+    })
+  })
+})

--- a/packages/github-action/src/conditions.ts
+++ b/packages/github-action/src/conditions.ts
@@ -8,9 +8,20 @@ export async function ifReleaseCommit(releaser: ReleaserGithubAction) {
     project
   } = releaser
   const message = await gitClient.exec('log', '-1', '--pretty=%B')
+
+  if (!message.startsWith('chore(release):')) {
+    return false
+  }
+
+  if (!releaser.options.dryRun) {
+    await gitClient.fetch({
+      tags: true
+    })
+  }
+
   const tags = await project.getTags()
 
-  return tags.length > 0 && message.startsWith('chore(release):')
+  return tags.length > 0
 }
 
 export function ifSetOptionsComment() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 22.16.2
       '@typescript/native-preview':
         specifier: latest
-        version: 7.0.0-dev.20260629.1
+        version: 7.0.0-dev.20260705.1
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
@@ -173,6 +173,9 @@ importers:
       '@simple-release/pnpm':
         specifier: workspace:^
         version: link:../pnpm
+      test:
+        specifier: workspace:^
+        version: link:../test
     publishDirectory: package
 
   packages/node-gha:
@@ -922,50 +925,50 @@ packages:
     resolution: {integrity: sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260629.1':
-    resolution: {integrity: sha512-wXRExZJweYoTzE4atRR7T5HwKJYkl6/KHxON0eF0iy2fvgLXDlyq4AQqhmV8mMx10PQKc/4sNbfhD4kjWWvm8A==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260705.1':
+    resolution: {integrity: sha512-OemjoGm+5nLCaUyL0zwWcSDhyQYQnO6/DcOidm2EzOqK7dYXgaCerDFUAz6iOGjOFtTAQFU50CV+ZbtUxodk9A==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260629.1':
-    resolution: {integrity: sha512-xkL/tETzUuDxfRkk2rD0/CjjjGLyOLHeE103T52rpgj0VNSXMnn7tTiw+TSdxnS61b8ImOrWgQJujhPFTp0jng==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260705.1':
+    resolution: {integrity: sha512-jYEsBtcVOin3ARa2xAkwM21KOlmr9s3FGxcY28gESigXPJOGooRaxZlJ45tFM3TczCMEGmML88XCXuQaH2z1kw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260629.1':
-    resolution: {integrity: sha512-y4ey82krq4iLNHML4G1dUObBWY6gNAjVqaUHFDv7+LBu5bfAJy8VClBaLtAJce3siQQeB0/4SkN4XsAa0oZktQ==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260705.1':
+    resolution: {integrity: sha512-kmWaZkuqb5RGTHt4AFIdPJ53/wO8vuZbmjSizNFNpvx1owYgQ8QZNu51zKfLQZbMs2FR7NAzVuQT14mhBaQW5Q==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260629.1':
-    resolution: {integrity: sha512-QlTxO+O6yELc0NYZZYIbncZhkhw+K/vBoVg+mKipbEIK5b1E6cwW7ivWIrDp1FfssQ0Wu7zxincPappoci7KNw==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260705.1':
+    resolution: {integrity: sha512-abTOyfyx5SW5szf1YeZf5K9vUWEE7nbbqUUthl8OgRrFrJzlZnDIRf/FV0h6QGqQIN7XTf8lgKjdFe4piNFLww==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260629.1':
-    resolution: {integrity: sha512-ckb4HyugC5beDpOMPOVpEx1H3l2Z2RgsGPxFOLGMU6LLIHQwlCaSdRjSfH8Hq8yffPgKuotTQLdA89cP1IC8xQ==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260705.1':
+    resolution: {integrity: sha512-oNA9I3MFLqdFVbwolnsFObjrQ1AsBXc4WXPcNyKcoaauAmFTwjxOBPKtiaqFKj4j4Abum7KvjVj0fgBaO5gRPA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260629.1':
-    resolution: {integrity: sha512-Ktgepu9p0blqrbiryzYrw11ddnbESXPdeGKURDG/wXESoHQETsMNxKWhqAo587ItNnWjKOBFxoEM22eP9OzKnw==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260705.1':
+    resolution: {integrity: sha512-K6hTgnqAEBbrIGH6feXM//FHbk0ilSAQDpLct+3IHfd+tg2sKop5lK2rTZkl/ptHM7Vlh0CF77m0RL73an+oAw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260629.1':
-    resolution: {integrity: sha512-b2wmeIpFJs/peej3NG26320ya+iYQz21JzFYDrnvtsEeR/g66rB9uvp4Owo4J1AG/BcmRWC/nuwrBy3Jdb+UDA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260705.1':
+    resolution: {integrity: sha512-gAwPJgfQWtJnZlMrJ8NCA+vdI42N+XLev+jqZnpcMqt+Jd2zMtoNpppHB0I6URMVys+R2WpMiOOSlHcnvOMyTQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260629.1':
-    resolution: {integrity: sha512-KImWFkxGUa/V78bUEAgzeJQT+6wKQXDDYHHrOavof8wnbMCpj86KuPNyBIPQMtoHiz2If8aNTums2m50oE3oqw==}
+  '@typescript/native-preview@7.0.0-dev.20260705.1':
+    resolution: {integrity: sha512-mXc3tDkRCe8UinMcl5yqUfLAP5Vk5MFuZNNaNsrwRehu1d+lnL+Zu+K7g6kSMOV8NOY9bn9tGFN4/cqhlK4VwA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -2928,36 +2931,36 @@ snapshots:
 
   '@typescript-eslint/types@8.62.0': {}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260629.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260705.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260629.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260705.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260629.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260705.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260629.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260705.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260629.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260705.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260629.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260705.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260629.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260705.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260629.1':
+  '@typescript/native-preview@7.0.0-dev.20260705.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260629.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260629.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260629.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260629.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260629.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260629.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260629.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260705.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260705.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260705.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260705.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260705.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260705.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260705.1
 
   '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
     dependencies:


### PR DESCRIPTION
## The problem

Dispatching the release workflow (e.g. a manual release via `workflow_dispatch`) while the branch HEAD is an already released `chore(release):` commit misdetects the context as `release` instead of `pull-request`.

`actions/checkout` produces a shallow clone without tags by default, and `ifReleaseCommit` verifies the release tag only locally (`git rev-parse --verify`). The tag for the current version is not found in the clone, so the commit is treated as a fresh release commit. The release flow then re-runs for the already published version and fails on publish:

```
409 Conflict - PUT https://npm.pkg.github.com/... - Cannot publish over existing version
```

Reproduced in real conditions: https://github.com/TrigenSoftware/dummy/actions/runs/28784646035

## The fix

`ifReleaseCommit` now fetches tags from the remote before checking them (same as the `tag` and `maintenanceBranch` steps do). The fetch is skipped when the commit message is not a release commit, and in `dryRun` mode.

Added unit tests for `ifReleaseCommit` reproducing the scenario with a real `--depth 1 --no-tags` clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)