### PR TITLE
fix(core,github-action): fetch refs before snapshot bump and always apply snapshot identifier

### DIFF
--- a/packages/core/src/project/packageJson.spec.ts
+++ b/packages/core/src/project/packageJson.spec.ts
@@ -187,6 +187,46 @@ describe('core', () => {
         expect(version).toMatch(/^2\.0\.1-canary\.\d{14}$/)
       })
 
+      it('should get next snapshot version for first release', async () => {
+        const { cwd } = await packageJsonProject()
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+        const version = await project.getNextVersion({
+          firstRelease: true,
+          snapshot: 'canary'
+        })
+
+        expect(version).toMatch(/^2\.0\.0-canary\.\d{14}$/)
+      })
+
+      it('should get next snapshot version from forced version', async () => {
+        const { cwd } = await packageJsonProject()
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+        const version = await project.getNextVersion({
+          version: '3.0.0',
+          snapshot: 'canary'
+        })
+
+        expect(version).toMatch(/^3\.0\.0-canary\.\d{14}$/)
+      })
+
+      it('should get next snapshot version without new commits', async () => {
+        const { cwd } = await packageJsonProject({}, {
+          postReleaseCommits: false
+        })
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+        const version = await project.getNextVersion({
+          snapshot: 'canary'
+        })
+
+        expect(version).toMatch(/^2\.0\.1-canary\.\d{14}$/)
+      })
+
       it('should dry bump version', async () => {
         const { cwd } = await packageJsonProject()
         const project = new PackageJsonProject({

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -16,7 +16,8 @@ import {
 import {
   getPrereleaseIdentifier,
   getPrereleaseIdentifierBase,
-  getReleaseType
+  getReleaseType,
+  setSnapshotIdentifier
 } from '../utils.js'
 import type {
   ProjectOptions,
@@ -262,7 +263,7 @@ export abstract class Project {
     let firstRelease = firstReleaseOption
 
     if (forcedVersion && semver.valid(forcedVersion)) {
-      return forcedVersion
+      return setSnapshotIdentifier(forcedVersion, snapshot)
     }
 
     const lastReleaseTag = await this.getLastReleaseTag({
@@ -276,7 +277,7 @@ export abstract class Project {
     const version = baseVersion || await manifest.getVersion()
 
     if (firstRelease) {
-      return version
+      return setSnapshotIdentifier(version, snapshot)
     }
 
     let releaseType: ReleaseType | null = null
@@ -300,7 +301,12 @@ export abstract class Project {
     }
 
     if (!releaseType) {
-      return null
+      if (!snapshot) {
+        return null
+      }
+
+      // Snapshot versions always should be released, even without new commits.
+      releaseType = 'patch'
     }
 
     const prereleaseIdentifier = getPrereleaseIdentifier(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -63,6 +63,18 @@ export function getPrereleaseIdentifierBase(snapshot?: string) {
     : undefined
 }
 
+export function setSnapshotIdentifier(version: string, snapshot?: string) {
+  if (!snapshot) {
+    return version
+  }
+
+  const semverVersion = new semver.SemVer(version)
+
+  semverVersion.prerelease = [snapshot, getSnapshotTimestamp()]
+
+  return semverVersion.format()
+}
+
 export function getReleaseType(
   releaseType: ReleaseType,
   version: string,

--- a/packages/github-action/src/releaser.spec.ts
+++ b/packages/github-action/src/releaser.spec.ts
@@ -1,0 +1,57 @@
+import { join } from 'path'
+import fs from 'fs/promises'
+import {
+  describe,
+  it,
+  expect,
+  vi
+} from 'vitest'
+import type { getOctokit } from '@actions/github'
+import { PnpmProject } from '@simple-release/pnpm'
+import {
+  createDirectory,
+  packageJsonProject
+} from 'test'
+import { ReleaserGithubAction } from './releaser.js'
+
+const octokit = {} as ReturnType<typeof getOctokit>
+
+describe('github-action', () => {
+  describe('releaser', () => {
+    describe('runSnapshotAction', () => {
+      it('should publish snapshot version from a shallow clone', async () => {
+        const { cwd } = await packageJsonProject({
+          name: 'snapshot-action-project'
+        })
+        const cloneCwd = await createDirectory('snapshot-action-clone')
+        const project = new PnpmProject({
+          path: join(cloneCwd, 'package.json')
+        })
+        const writeVersion = vi.spyOn(project.manifest, 'writeVersion')
+        const releaser = new ReleaserGithubAction({
+          project,
+          octokit,
+          silent: true
+        })
+          .setOptions({
+            publish: {
+              skip: true
+            }
+          })
+
+        // Clone the repository like actions/checkout does by default: depth 1 and no tags.
+        await project.gitClient.exec('clone', '--depth', '1', '--no-tags', `file://${cwd}`, '.')
+
+        await releaser.runSnapshotAction('canary')
+
+        expect(writeVersion.mock.calls[0][0]).toMatch(/^2\.1\.0-canary\.\d{14}$/)
+
+        const packageJson = JSON.parse(
+          await fs.readFile(join(cloneCwd, 'package.json'), 'utf-8')
+        ) as Record<string, string>
+
+        expect(packageJson.version).toBe('2.0.0')
+      })
+    })
+  })
+})

--- a/packages/github-action/src/releaser.ts
+++ b/packages/github-action/src/releaser.ts
@@ -112,6 +112,32 @@ export class ReleaserGithubAction<P extends Project = Project> extends Releaser<
     })
   }
 
+  /**
+   * Fetch all commits and tags from the remote repository.
+   * @returns Project releaser instance for chaining.
+   */
+  fetch() {
+    return this.enqueue(async () => {
+      const {
+        logger,
+        gitClient
+      } = this
+      const { dryRun } = this.options
+
+      logger.info('fetch', 'Fetching all commits and tags from the remote repository...')
+
+      if (!dryRun) {
+        await gitClient.fetch({
+          prune: true,
+          unshallow: await gitClient.exec('rev-parse', '--is-shallow-repository') === 'true',
+          tags: true,
+          remote: 'origin',
+          branch: 'HEAD'
+        })
+      }
+    })
+  }
+
   override tag() {
     return super.tag({
       fetch: true
@@ -164,6 +190,7 @@ export class ReleaserGithubAction<P extends Project = Project> extends Releaser<
     }
 
     await this
+      .fetch()
       .bump({
         snapshot: snapshotTag,
         skipChangelog: true


### PR DESCRIPTION
## The problem

The snapshot flow (`runSnapshotAction`) runs directly on the default `actions/checkout` state — depth 1, no tags — without any fetch step (unlike the pull request and release flows, whose `checkout` step fetches history and tags). With no tags visible, `getNextVersion` auto-detects the first release and returns the current manifest version unchanged — no snapshot suffix at all — and publishing fails over the existing version:

```
[bump]: @trigensoftware/dummy-foo: 1.1.0
409 Conflict - Cannot publish over existing version
```

Reproduced in real conditions: https://github.com/TrigenSoftware/dummy/actions/runs/28792801919

## The fix

- **github-action**: new `fetch` step (unshallow when needed + tags, no branch switch, so the dispatched ref stays checked out), prepended to `runSnapshotAction`.
- **core**: when the `snapshot` option is set, the version always gets the snapshot prerelease identifier — including forced versions, first releases, and bumps without new commits (falls back to a patch bump). Snapshot versions can never collide with real released versions anymore.

Covered by specs: snapshot versions for forced/first-release/no-commits cases in core, and `runSnapshotAction` on a real `--depth 1 --no-tags` clone in github-action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)