### PR TITLE
feat(core,github): do not mark maintenance releases as latest

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -179,6 +179,8 @@ await new Releaser({
 | --- | --- |
 | `enabled` | Enable maintenance branch creation. Defaults to `false`. |
 | `force` | Recreate an existing maintenance branch. |
+| `tagPrefix` | Prefix used for release tags. Defaults to `v`. |
+| `branchPrefix` | Prefix used for the maintenance branch name. Defaults to the tag prefix. |
 
 ```js
 await new Releaser({
@@ -220,6 +222,8 @@ For independent monorepos, maintenance branches use each package tag prefix. Use
 | `skip` | Skip publishing. |
 | `tag` | Publish tag or formatter function. |
 | `gitChecks` | Whether to perform git checks before publishing when the addon supports it. |
+
+When `tag` is not set, it defaults to the prerelease identifier for prerelease versions (e.g. `alpha`), or to `release-N.x` for maintenance releases of previous majors, so they never overwrite the `latest` tag.
 
 #### release and pullRequest
 

--- a/packages/core/src/hosting/hosting.types.ts
+++ b/packages/core/src/hosting/hosting.types.ts
@@ -8,6 +8,7 @@ export interface ReleaseData {
   previousTag: string
   nextTag: string
   isPrerelease: boolean
+  isLatest: boolean
 }
 
 export interface CreateReleaseOptions {

--- a/packages/core/src/project/monorepo.ts
+++ b/packages/core/src/project/monorepo.ts
@@ -10,7 +10,7 @@ import type {
 import {
   type ProjectOptions,
   type ProjectMaintenanceBranch,
-  type ProjectReleaseOptions,
+  type ProjectMaintenanceBranchesOptions,
   type ProjectRevertOptions,
   Project,
   bumpDefaultOptions
@@ -198,7 +198,7 @@ export abstract class MonorepoProject extends Project {
     return this.getIndependentReleaseData()
   }
 
-  private async getIndependentMaintenanceBranches() {
+  private async getIndependentMaintenanceBranches(options: ProjectMaintenanceBranchesOptions) {
     const branches: ProjectMaintenanceBranch[] = []
 
     for await (const project of this.getProjects()) {
@@ -208,6 +208,7 @@ export abstract class MonorepoProject extends Project {
       const tagPrefix = await this.getTagPrefix(scope)
 
       branches.push(...await project.getMaintenanceBranches({
+        ...options,
         tagPrefix
       }))
     }
@@ -215,14 +216,14 @@ export abstract class MonorepoProject extends Project {
     return branches
   }
 
-  override async getMaintenanceBranches(options: ProjectReleaseOptions = {}) {
+  override async getMaintenanceBranches(options: ProjectMaintenanceBranchesOptions = {}) {
     const { mode } = this
 
     if (mode === 'fixed') {
       return super.getMaintenanceBranches(options)
     }
 
-    return this.getIndependentMaintenanceBranches()
+    return this.getIndependentMaintenanceBranches(options)
   }
 
   private async getBumpOptions(

--- a/packages/core/src/project/packageJson.spec.ts
+++ b/packages/core/src/project/packageJson.spec.ts
@@ -7,7 +7,8 @@ import {
 } from 'vitest'
 import {
   packageJsonProject,
-  forkProject
+  forkProject,
+  dummyCommit
 } from 'test'
 import { PackageJsonProject } from './packageJson.js'
 
@@ -48,7 +49,8 @@ describe('core', () => {
             previousTag: 'v1.0.0',
             nextTag: 'v2.0.0',
             notes: 'RELEASE NOTES',
-            isPrerelease: false
+            isPrerelease: false,
+            isLatest: true
           }
         ])
       })
@@ -90,6 +92,24 @@ describe('core', () => {
         })
 
         expect(await project.getMaintenanceBranches()).toEqual([])
+      })
+
+      it('should get maintenance branch refs with custom branch prefix', async () => {
+        const { cwd } = await packageJsonProject({
+          version: '3.0.0'
+        })
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+
+        expect(await project.getMaintenanceBranches({
+          branchPrefix: 'maintenance-v'
+        })).toEqual([
+          {
+            from: 'v2.0.0',
+            to: 'maintenance-v2'
+          }
+        ])
       })
 
       it('should get next version', async () => {
@@ -225,6 +245,45 @@ describe('core', () => {
         })
 
         expect(version).toMatch(/^2\.0\.1-canary\.\d{14}$/)
+      })
+
+      it('should detect latest release', async () => {
+        const { cwd } = await packageJsonProject()
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+
+        expect(await project.isLatestRelease()).toBe(true)
+      })
+
+      it('should not detect maintenance release as latest', async () => {
+        const { cwd, run } = await forkProject('maintenance-latest', packageJsonProject())
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+
+        await run([
+          ({ git }) => git.exec('checkout', '-b', 'next-major'),
+          ctx => dummyCommit(ctx, 'feat'),
+          ({ git }) => git.exec('tag', 'v3.0.0'),
+          ({ git }) => git.exec('checkout', 'master'),
+          ({ git }) => git.exec('branch', '-D', 'next-major')
+        ])
+
+        expect(await project.isLatestRelease()).toBe(false)
+      })
+
+      it('should ignore prerelease tags while detecting latest release', async () => {
+        const { cwd, run } = await forkProject('prerelease-latest', packageJsonProject())
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+
+        await run([
+          ({ git }) => git.exec('tag', 'v3.0.0-alpha.0')
+        ])
+
+        expect(await project.isLatestRelease()).toBe(true)
       })
 
       it('should dry bump version', async () => {

--- a/packages/core/src/project/packageJsonMonorepo.spec.ts
+++ b/packages/core/src/project/packageJsonMonorepo.spec.ts
@@ -83,7 +83,8 @@ describe('core', () => {
               previousTag: 'v1.0.0',
               nextTag: 'v2.0.0',
               title: 'subproject-1: v2.0.0',
-              isPrerelease: false
+              isPrerelease: false,
+              isLatest: true
             },
             {
               version: '2.0.0',
@@ -91,7 +92,8 @@ describe('core', () => {
               previousTag: 'v1.0.0',
               nextTag: 'v2.0.0',
               title: 'subproject-2: v2.0.0',
-              isPrerelease: false
+              isPrerelease: false,
+              isLatest: true
             },
             {
               version: '2.0.0',
@@ -99,7 +101,8 @@ describe('core', () => {
               previousTag: 'v1.0.0',
               nextTag: 'v2.0.0',
               title: 'subproject-3: v2.0.0',
-              isPrerelease: false
+              isPrerelease: false,
+              isLatest: true
             }
           ])
         })
@@ -124,7 +127,8 @@ describe('core', () => {
               previousTag: 'v1.0.0',
               nextTag: 'v2.0.0',
               title: 'subproject-1: v2.0.0',
-              isPrerelease: false
+              isPrerelease: false,
+              isLatest: true
             },
             {
               version: '2.0.0',
@@ -132,7 +136,8 @@ describe('core', () => {
               previousTag: 'v1.0.0',
               nextTag: 'v2.0.0',
               title: 'subproject-3: v2.0.0',
-              isPrerelease: false
+              isPrerelease: false,
+              isLatest: true
             }
           ])
         })
@@ -285,7 +290,8 @@ describe('core', () => {
               previousTag: 'v1.0.0',
               nextTag: 'v2.0.0',
               title: 'v2.0.0',
-              isPrerelease: false
+              isPrerelease: false,
+              isLatest: true
             }
           ])
         })

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -25,12 +25,15 @@ import type {
   ProjectVersionUpdate,
   ProjectTagsOptions,
   ProjectReleaseOptions,
+  ProjectMaintenanceBranchesOptions,
   ProjectMaintenanceBranch,
   ProjectPublishOptions,
   ProjectRevertOptions
 } from './project.types.js'
 
 export type * from './project.types.js'
+
+export const DEFAULT_TAG_PREFIX = 'v'
 
 export const bumpDefaultOptions = {
   preset: {
@@ -115,7 +118,7 @@ export abstract class Project {
       gitClient
     } = this
     const {
-      tagPrefix = 'v',
+      tagPrefix = DEFAULT_TAG_PREFIX,
       verify = true
     } = options
     const version = await manifest.getVersion()
@@ -171,7 +174,8 @@ export abstract class Project {
         ...lastRelease,
         title: `v${version}`,
         version,
-        isPrerelease
+        isPrerelease,
+        isLatest: await this.isLatestRelease(options)
       }
     ]
   }
@@ -195,13 +199,40 @@ export abstract class Project {
   }
 
   /**
+   * Check whether the current version is the latest release of the project.
+   * Maintenance branch releases of previous majors are not the latest ones.
+   * @param options - The options to use for detecting tags.
+   * @returns Whether the current version is the latest release.
+   */
+  async isLatestRelease(options: ProjectReleaseOptions = {}): Promise<boolean> {
+    const { tagPrefix = DEFAULT_TAG_PREFIX } = options
+    const version = await this.manifest.getVersion()
+    const currentVersion = semver.valid(version)
+
+    if (!currentVersion) {
+      return true
+    }
+
+    const latestVersion = await this.gitClient.getVersionFromTags({
+      prefix: tagPrefix,
+      skipUnstable: true,
+      all: true
+    })
+
+    return !latestVersion || semver.gte(currentVersion, latestVersion)
+  }
+
+  /**
    * Get maintenance branch refs to create after a major version release.
    * @param options - The options to use for detecting tags and formatting branches.
    * @returns Maintenance branch refs.
    */
-  async getMaintenanceBranches(options: ProjectReleaseOptions = {}): Promise<ProjectMaintenanceBranch[]> {
+  async getMaintenanceBranches(options: ProjectMaintenanceBranchesOptions = {}): Promise<ProjectMaintenanceBranch[]> {
     const { manifest } = this
-    const { tagPrefix = 'v' } = options
+    const {
+      tagPrefix = DEFAULT_TAG_PREFIX,
+      branchPrefix = tagPrefix
+    } = options
     const version = await manifest.getVersion()
     const currentVersion = semver.valid(version)
 
@@ -225,7 +256,7 @@ export abstract class Project {
         return [
           {
             from: previousTag,
-            to: `${tagPrefix}${semver.major(previousVersion)}`
+            to: `${branchPrefix}${semver.major(previousVersion)}`
           }
         ]
       }

--- a/packages/core/src/project/project.types.ts
+++ b/packages/core/src/project/project.types.ts
@@ -109,6 +109,14 @@ export interface ProjectReleaseOptions {
   tagPrefix?: string
 }
 
+export interface ProjectMaintenanceBranchesOptions extends ProjectReleaseOptions {
+  /**
+   * The prefix to use for the maintenance branch name.
+   * Defaults to the tag prefix.
+   */
+  branchPrefix?: string
+}
+
 export interface ProjectMaintenanceBranch {
   /**
    * Source tag to create the branch from.

--- a/packages/core/src/releaser.spec.ts
+++ b/packages/core/src/releaser.spec.ts
@@ -3,12 +3,14 @@ import { join } from 'path'
 import {
   describe,
   it,
-  expect
+  expect,
+  vi
 } from 'vitest'
 import { GitClient } from '@conventional-changelog/git-client'
 import { firstFromStream } from '@simple-libs/stream-utils'
 import {
   createDirectory,
+  dummyCommit,
   forkProject,
   packageJsonProject
 } from 'test'
@@ -151,6 +153,32 @@ describe('core', () => {
       expect(await project.gitClient.exec('ls-remote', '--heads', 'origin', 'v2')).toContain('refs/heads/v2')
     })
 
+    it('should create maintenance branches with custom branch prefix', async () => {
+      const { cwd } = await forkProject('maintenance-branch-prefix', packageJsonProject({
+        version: '3.0.0'
+      }))
+      const remote = await createDirectory('maintenance-branch-prefix-remote')
+      const remoteGit = new GitClient(remote)
+      const project = new PackageJsonProject({
+        path: join(cwd, 'package.json')
+      })
+      const releaser = new Releaser({
+        project,
+        silent: true
+      })
+        .maintenanceBranch({
+          enabled: true,
+          branchPrefix: 'maintenance-v'
+        })
+
+      await remoteGit.exec('init', '--bare')
+      await project.gitClient.exec('remote', 'set-url', 'origin', remote)
+      await releaser.run()
+
+      expect(await project.gitClient.verify('refs/heads/maintenance-v2', true)).not.toBe('')
+      expect(await project.gitClient.exec('ls-remote', '--heads', 'origin', 'maintenance-v2')).toContain('refs/heads/maintenance-v2')
+    })
+
     it('should not create maintenance branches by default', async () => {
       const { cwd } = await forkProject('maintenance-branch-disabled', packageJsonProject({
         version: '3.0.0'
@@ -167,6 +195,101 @@ describe('core', () => {
       await releaser.run()
 
       expect(await project.gitClient.verify('refs/heads/v2', true)).toBe('')
+    })
+
+    it('should publish latest release without npm tag', async () => {
+      const { cwd } = await packageJsonProject()
+      const project = new PackageJsonProject({
+        path: join(cwd, 'package.json')
+      })
+      const publish = vi.spyOn(project, 'publish').mockResolvedValue()
+      const releaser = new Releaser({
+        project,
+        silent: true
+      })
+        .publish()
+
+      await releaser.run()
+
+      expect(publish.mock.calls[0][0]).toMatchObject({
+        tag: undefined
+      })
+    })
+
+    it('should publish maintenance release with major npm tag', async () => {
+      const { cwd, run } = await forkProject('publish-maintenance-tag', packageJsonProject())
+      const project = new PackageJsonProject({
+        path: join(cwd, 'package.json')
+      })
+      const publish = vi.spyOn(project, 'publish').mockResolvedValue()
+
+      await run([
+        ({ git }) => git.exec('checkout', '-b', 'next-major'),
+        ctx => dummyCommit(ctx, 'feat'),
+        ({ git }) => git.exec('tag', 'v3.0.0'),
+        ({ git }) => git.exec('checkout', 'master'),
+        ({ git }) => git.exec('branch', '-D', 'next-major')
+      ])
+
+      const releaser = new Releaser({
+        project,
+        silent: true
+      })
+        .publish()
+
+      await releaser.run()
+
+      expect(publish.mock.calls[0][0]).toMatchObject({
+        tag: 'release-2.x'
+      })
+    })
+
+    it('should publish prerelease with prerelease npm tag', async () => {
+      const { cwd } = await packageJsonProject({
+        name: 'publish-prerelease-tag-project',
+        version: '2.1.0-alpha.0'
+      })
+      const project = new PackageJsonProject({
+        path: join(cwd, 'package.json')
+      })
+      const publish = vi.spyOn(project, 'publish').mockResolvedValue()
+      const releaser = new Releaser({
+        project,
+        silent: true
+      })
+        .publish()
+
+      await releaser.run()
+
+      expect(publish.mock.calls[0][0]).toMatchObject({
+        tag: 'alpha'
+      })
+    })
+
+    it('should publish with explicit npm tag', async () => {
+      const { cwd, run } = await forkProject('publish-explicit-tag', packageJsonProject())
+      const project = new PackageJsonProject({
+        path: join(cwd, 'package.json')
+      })
+      const publish = vi.spyOn(project, 'publish').mockResolvedValue()
+
+      await run([
+        ({ git }) => git.exec('tag', 'v3.0.0')
+      ])
+
+      const releaser = new Releaser({
+        project,
+        silent: true
+      })
+        .publish({
+          tag: 'custom'
+        })
+
+      await releaser.run()
+
+      expect(publish.mock.calls[0][0]).toMatchObject({
+        tag: 'custom'
+      })
     })
   })
 })

--- a/packages/core/src/releaser.ts
+++ b/packages/core/src/releaser.ts
@@ -1,4 +1,5 @@
 import type { ConventionalGitClient } from '@conventional-changelog/git-client'
+import semver from 'semver'
 import type { Project } from './project/index.js'
 import type { GitRepositoryHosting } from './hosting/index.js'
 import type {
@@ -342,7 +343,8 @@ export class Releaser<
       const { dryRun } = this.options
       const {
         enabled,
-        force
+        force,
+        ...branchesOptions
       } = {
         ...this.stepsOptions.maintenanceBranch,
         ...options
@@ -363,7 +365,7 @@ export class Releaser<
         })
       }
 
-      const branches = await project.getMaintenanceBranches()
+      const branches = await project.getMaintenanceBranches(branchesOptions)
 
       if (!branches.length) {
         logger.info('maintenance-branch', 'No maintenance branches to create.')
@@ -519,10 +521,39 @@ export class Releaser<
         return
       }
 
+      // Maintenance and prerelease versions should not get the default `latest` npm tag.
+      publishOptions.tag ||= await this.getDefaultPublishTag()
+
       logger.info('Publishing...')
 
       await project.publish(publishOptions)
     })
+  }
+
+  private async getDefaultPublishTag() {
+    const { project } = this
+    const { manifest } = project
+    const prerelease = await manifest.getPrereleaseVersion()
+
+    if (prerelease) {
+      const [identifier] = prerelease
+
+      return typeof identifier === 'string'
+        ? identifier
+        : 'next'
+    }
+
+    const isLatestRelease = await project.isLatestRelease({
+      tagPrefix: this.stepsOptions.bump?.tagPrefix
+    })
+
+    if (!isLatestRelease) {
+      const version = await manifest.getVersion()
+
+      return `release-${semver.major(version)}.x`
+    }
+
+    return undefined
   }
 
   /**

--- a/packages/core/src/releaser.types.ts
+++ b/packages/core/src/releaser.types.ts
@@ -3,7 +3,10 @@ import type {
   GitTagParams,
   GitPushParams
 } from '@conventional-changelog/git-client'
-import type { Project } from './project/index.js'
+import type {
+  Project,
+  ProjectMaintenanceBranchesOptions
+} from './project/index.js'
 import type { GitRepositoryHosting } from './hosting/index.js'
 import type { Logger } from './logger.js'
 
@@ -64,7 +67,7 @@ export interface ReleaserTagOptions extends Omit<GitTagParams, 'name' | 'message
   fetch?: boolean
 }
 
-export interface ReleaserMaintenanceBranchOptions extends Pick<GitPushParams, 'force'> {
+export interface ReleaserMaintenanceBranchOptions extends Pick<GitPushParams, 'force'>, ProjectMaintenanceBranchesOptions {
   /**
    * Enable maintenance branch creation.
    */

--- a/packages/github/src/index.spec.ts
+++ b/packages/github/src/index.spec.ts
@@ -4,7 +4,11 @@ import {
   it,
   expect
 } from 'vitest'
-import { packageJsonProject } from 'test'
+import {
+  dummyCommit,
+  forkProject,
+  packageJsonProject
+} from 'test'
 import {
   type LoggerMessage,
   PackageJsonProject,
@@ -45,6 +49,49 @@ describe('github', () => {
         name: 'v2.0.0',
         body: 'RELEASE NOTES',
         prerelease: false
+      })
+    })
+
+    it('should not mark maintenance release as latest', async () => {
+      const { cwd, run } = await forkProject('github-maintenance-release', packageJsonProject())
+      const project = new PackageJsonProject({
+        path: join(cwd, 'package.json')
+      })
+      const log: LoggerMessage[] = []
+      const logger = new Logger({
+        verbose: true,
+        printer(message) {
+          log.push(message)
+        }
+      })
+      const publusher = new GithubHosting({
+        token: ''
+      })
+
+      await run([
+        ({ git }) => git.exec('checkout', '-b', 'next-major'),
+        ctx => dummyCommit(ctx, 'feat'),
+        ({ git }) => git.exec('tag', 'v3.0.0'),
+        ({ git }) => git.exec('checkout', 'master'),
+        ({ git }) => git.exec('branch', '-D', 'next-major')
+      ])
+
+      await publusher.createRelease({
+        project,
+        dryRun: true,
+        logger: logger.createChild('release')
+      })
+
+      const release = log[1].message
+
+      expect(release).toEqual({
+        owner: 'TrigenSoftware',
+        repo: 'test-repo',
+        tag_name: 'v2.0.0',
+        name: 'v2.0.0',
+        body: 'RELEASE NOTES',
+        prerelease: false,
+        make_latest: 'false'
       })
     })
   })

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -132,7 +132,10 @@ export class GithubHosting extends GitRepositoryHosting {
         tag_name: releaseData.nextTag,
         name: releaseData.title,
         body: releaseData.notes,
-        prerelease: releaseData.isPrerelease
+        prerelease: releaseData.isPrerelease,
+        make_latest: releaseData.isLatest
+          ? undefined
+          : 'false' as const
       }
 
       logger?.verbose('Creating release with params:')

--- a/packages/node-gha/src/project.ts
+++ b/packages/node-gha/src/project.ts
@@ -2,6 +2,7 @@ import {
   type PackageJsonProjectOptions,
   type ProjectBumpOptions,
   type ProjectReleaseOptions,
+  DEFAULT_TAG_PREFIX,
   PackageJsonProject
 } from '@simple-release/core'
 import {
@@ -37,7 +38,7 @@ export class NodeGhaProject extends PackageJsonProject {
    * @returns The last release tag, `null` if not found.
    */
   override async getLastReleaseTag(options: ProjectReleaseOptions = {}) {
-    const { tagPrefix = 'v' } = options
+    const { tagPrefix = DEFAULT_TAG_PREFIX } = options
     const tags = this.gitClient.getSemverTags({
       prefix: tagPrefix,
       all: true

--- a/packages/node-gha/src/publish.ts
+++ b/packages/node-gha/src/publish.ts
@@ -1,7 +1,8 @@
 import { spawn } from 'child_process'
-import type {
-  PackageJsonProject,
-  ProjectPublishOptions
+import {
+  type PackageJsonProject,
+  type ProjectPublishOptions,
+  DEFAULT_TAG_PREFIX
 } from '@simple-release/core'
 import { throwProcessError } from '@simple-libs/child-process-utils'
 import semverMajor from 'semver/functions/major.js'
@@ -71,8 +72,8 @@ export async function publish(project: PackageJsonProject, options: PublishOptio
   } = project
   const {
     latestBranch = 'latest',
-    majorBranchPrefix = 'v',
-    tagPrefix = 'v',
+    majorBranchPrefix = DEFAULT_TAG_PREFIX,
+    tagPrefix = DEFAULT_TAG_PREFIX,
     dryRun,
     logger
   } = options


### PR DESCRIPTION
## The problem

Releasing from a maintenance branch (e.g. `1.1.1` from `v1` after `2.0.0` is out) hijacks the "latest" pointers:

- `npm publish` without an explicit tag always sets the `latest` dist-tag — the registry's `latest` rolls back to the old major;
- `GithubHosting.createRelease` doesn't pass `make_latest`, and the API default marks the newly created release as **Latest** in the UI.

Prerelease versions published without an explicit tag overwrite the `latest` dist-tag as well.

## The fix

- **core**: new `Project#isLatestRelease(options)` — the current version is the latest when it is `>=` the highest stable release tag across all refs (`getSemverTags({ all: true, skipUnstable: true })`). Exposed as `isLatest` in `ReleaseData`.
- **core**: the releaser `publish` step now computes a default `tag` when not set explicitly: the prerelease identifier for prerelease versions (e.g. `alpha`), or `release-N.x` (semantic-release convention) for maintenance releases. Latest releases keep the current behavior.
- **github**: `createRelease` passes `make_latest: 'false'` for non-latest releases.
- **core**: `getMaintenanceBranches` accepts a `branchPrefix` option (defaults to the tag prefix) to decouple maintenance branch naming from tag naming; exposed through the `maintenanceBranch` releaser step options.
- `DEFAULT_TAG_PREFIX` constant replaces the hardcoded `'v'` defaults across core and node-gha.

Covered by specs: `isLatestRelease` (latest / maintenance / prerelease tags ignored), default publish tag (latest / maintenance / prerelease / explicit), `make_latest` in GitHub release params, and custom `branchPrefix` for maintenance branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)