### PR TITLE
fix(pnpm,github-action): disable git checks on publish by default

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -164,8 +164,7 @@ await new Releaser({
     skipChangelog: true
   })
   .publish({
-    tag: 'canary',
-    gitChecks: false
+    tag: 'canary'
   })
   .revert()
   .run()

--- a/packages/github-action/README.md
+++ b/packages/github-action/README.md
@@ -181,8 +181,7 @@ action
     skipChangelog: true
   })
   .publish({
-    tag: snapshotTag,
-    gitChecks: false
+    tag: snapshotTag
   })
   .revert()
   .run()

--- a/packages/github-action/src/releaser.ts
+++ b/packages/github-action/src/releaser.ts
@@ -196,8 +196,7 @@ export class ReleaserGithubAction<P extends Project = Project> extends Releaser<
         skipChangelog: true
       } as PickOverridableOptions<P['bump']>)
       .publish({
-        tag: snapshotTag,
-        gitChecks: false
+        tag: snapshotTag
       } as PickOverridableOptions<P['publish']>)
       .revert()
       .run()

--- a/packages/pnpm/README.md
+++ b/packages/pnpm/README.md
@@ -173,7 +173,7 @@ One-time password for publishing. Optional.
 
 #### `gitChecks`
 
-Whether to run git checks before publishing. Defaults to `true`.
+Whether to run git checks before publishing. Disabled by default: the release flow publishes from the released commit, and pnpm branch checks fail releases from non-default branches, like maintenance ones.
 
 #### `env`
 

--- a/packages/pnpm/src/publish.ts
+++ b/packages/pnpm/src/publish.ts
@@ -18,7 +18,7 @@ export async function publish(project: PackageJsonProject, options: PublishOptio
     access,
     tag,
     otp,
-    gitChecks = true,
+    gitChecks = false,
     env = process.env,
     workspaces,
     dryRun,


### PR DESCRIPTION
## The problem

`pnpm publish` runs its own git checks: the `publish-branch` check rejects publishing from any branch except `master|main`, so a maintenance release from a `v1` branch fails:

```
ERR_PNPM_GIT_NOT_CORRECT_BRANCH: Branch is not on 'master|main'.
```

Reproduced in real conditions: https://github.com/TrigenSoftware/dummy/actions/runs/28801973337 — note the run stayed green while the package was never published (pnpm exits with code 0 after the declined prompt in CI), so the GitHub release was created without the package.

## The fix

- **pnpm**: `gitChecks` defaults to `false`. The release flow publishes from the released commit which the releaser controls itself, so pnpm branch/worktree checks add nothing there — and `npm publish` performs no git checks at all, so this also aligns the two addons. Explicit `gitChecks: true` keeps the checks.
- **github-action**: the now-redundant explicit `gitChecks: false` is removed from the snapshot flow; docs examples updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)