### PR TITLE
fix(core): pass options to monorepo tags and release data overrides

### DIFF
--- a/packages/core/src/project/monorepo.ts
+++ b/packages/core/src/project/monorepo.ts
@@ -9,6 +9,8 @@ import type {
 } from './monorepo.types.js'
 import {
   type ProjectOptions,
+  type ProjectTagsOptions,
+  type ProjectReleaseOptions,
   type ProjectMaintenanceBranch,
   type ProjectMaintenanceBranchesOptions,
   type ProjectRevertOptions,
@@ -140,7 +142,7 @@ export abstract class MonorepoProject extends Project {
     return this.getIndependentCommitMessage()
   }
 
-  private async getIndependentTags() {
+  private async getIndependentTags(options: ProjectTagsOptions) {
     const tags: string[] = []
 
     for await (const project of this.getProjects()) {
@@ -150,6 +152,7 @@ export abstract class MonorepoProject extends Project {
       const tagPrefix = await this.getTagPrefix(scope)
 
       tags.push(...await project.getTags({
+        ...options,
         tagPrefix
       }))
     }
@@ -157,17 +160,17 @@ export abstract class MonorepoProject extends Project {
     return tags
   }
 
-  override async getTags() {
+  override async getTags(options: ProjectTagsOptions = {}) {
     const { mode } = this
 
     if (mode === 'fixed') {
-      return super.getTags()
+      return super.getTags(options)
     }
 
-    return this.getIndependentTags()
+    return this.getIndependentTags(options)
   }
 
-  private async getIndependentReleaseData() {
+  private async getIndependentReleaseData(options: ProjectReleaseOptions) {
     const data: ReleaseData[] = []
 
     for await (const project of this.getProjects()) {
@@ -176,6 +179,7 @@ export abstract class MonorepoProject extends Project {
       const scope = await this.getScope(name)
       const tagPrefix = await this.getTagPrefix(scope)
       const releaseData = await project.getReleaseData({
+        ...options,
         tagPrefix
       })
 
@@ -188,14 +192,14 @@ export abstract class MonorepoProject extends Project {
     return data
   }
 
-  override async getReleaseData() {
+  override async getReleaseData(options: ProjectReleaseOptions = {}) {
     const { mode } = this
 
     if (mode === 'fixed') {
-      return super.getReleaseData()
+      return super.getReleaseData(options)
     }
 
-    return this.getIndependentReleaseData()
+    return this.getIndependentReleaseData(options)
   }
 
   private async getIndependentMaintenanceBranches(options: ProjectMaintenanceBranchesOptions) {

--- a/packages/core/src/project/packageJsonMonorepo.spec.ts
+++ b/packages/core/src/project/packageJsonMonorepo.spec.ts
@@ -312,6 +312,34 @@ describe('core', () => {
           expect(release).toEqual([])
         })
 
+        it('should get release data with existing tag from changelog without compare links', async () => {
+          const { cwd } = await forkProject('fixed-release-data-no-links', packageJsonFixedMonorepoProject())
+          const project = new PackageJsonMonorepoProject({
+            mode: 'fixed',
+            root: cwd,
+            getProjects
+          })
+
+          await fs.writeFile(
+            join(cwd, 'CHANGELOG.md'),
+            '# Changelog\n\n## 2.0.0 (2017-06-20)\n\nRELEASE NOTES\n'
+          )
+
+          const release = await project.getReleaseData()
+
+          expect(release).toEqual([
+            {
+              version: '2.0.0',
+              notes: 'RELEASE NOTES',
+              previousTag: '',
+              nextTag: 'v2.0.0',
+              title: 'v2.0.0',
+              isPrerelease: false,
+              isLatest: true
+            }
+          ])
+        })
+
         it('should get maintenance branch refs', async () => {
           const { cwd } = await packageJsonFixedMonorepoProject({
             0: {


### PR DESCRIPTION
## The problem

`MonorepoProject` overrides of `getTags` and `getReleaseData` don't accept or forward options. `getReleaseData` falls back to `getTags({ verify: false })` when the changelog section has no compare link (the first release), but the override drops `verify: false` — the just-created tag is treated as already existing, no next tag is resolved, and the GitHub release creation fails:

```
Validation Failed: {"resource":"Release","code":"missing_field","field":"tag_name"}
```

Reproduced in real conditions on the first release of a fixed monorepo: https://github.com/TrigenSoftware/dummy-fixed-monorepo/actions/runs/28808662125 — the tag was pushed and all packages were published, but the GitHub release was not created.

## The fix

`getTags` and `getReleaseData` monorepo overrides now accept options and forward them to the base implementation (fixed mode) and to per-package calls (independent mode, keeping the per-package `tagPrefix`).

Covered by a spec: fixed monorepo release data with an existing tag and a changelog section without compare links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)