### PR TITLE
fix(core): decode tags extracted from changelog compare links

### DIFF
--- a/packages/core/src/change-log.ts
+++ b/packages/core/src/change-log.ts
@@ -97,6 +97,14 @@ export async function addReleaseNotes(
   return changes
 }
 
+function decodeTag(tag: string) {
+  try {
+    return decodeURIComponent(tag)
+  } catch {
+    return tag
+  }
+}
+
 /**
  * Extract the last release notes from a stream.
  * @param input
@@ -134,10 +142,9 @@ export async function extractLastRelease(input: string | string[] | Iterable<str
         const tagsMatch = line.match(tagsRegex)
 
         if (tagsMatch) {
-          [
-            , previousTag,
-            nextTag
-          ] = tagsMatch
+          // Tags are extracted from the compare link and can be URL-encoded.
+          previousTag = decodeTag(tagsMatch[1])
+          nextTag = decodeTag(tagsMatch[2])
         }
 
         continue

--- a/packages/core/src/changelog.spec.ts
+++ b/packages/core/src/changelog.spec.ts
@@ -12,6 +12,7 @@ import {
 import {
   changelogHeader,
   addReleaseNotes,
+  extractLastRelease,
   extractLastReleaseFromFile
 } from './change-log.js'
 
@@ -108,6 +109,20 @@ describe('core', () => {
             "version": "1.0.0",
           }
         `)
+      })
+    })
+
+    describe('extractLastRelease', () => {
+      it('should decode tags extracted from the compare link', async () => {
+        const result = await extractLastRelease(
+          '## [1.1.0](https://github.com/TrigenSoftware/dummy-independent-monorepo/compare/dummy-independent-monorepo-foo%401.0.0...dummy-independent-monorepo-foo%401.1.0) (2026-07-06)\n\nRELEASE NOTES\n'
+        )
+
+        expect(result).toMatchObject({
+          version: '1.1.0',
+          previousTag: 'dummy-independent-monorepo-foo@1.0.0',
+          nextTag: 'dummy-independent-monorepo-foo@1.1.0'
+        })
       })
     })
   })


### PR DESCRIPTION
## The problem

Tag prefixes with special characters get URL-encoded in changelog compare links (e.g. `dummy-independent-monorepo-foo%401.1.0` for the `<package>@<version>` tags of independent monorepos). `extractLastRelease` parses `previousTag`/`nextTag` out of that link without decoding, so:

- the GitHub release is created with a percent-encoded `tag_name` — the API silently creates a garbage tag (`...%401.1.0`) alongside the real one and attaches the release to it;
- `previousTag` is used as the source for maintenance branches — a major release would try to branch from a non-existent encoded tag.

Reproduced in real conditions: https://github.com/TrigenSoftware/dummy-independent-monorepo/actions/runs/28818056512 — release attached to the literal `dummy-independent-monorepo-foo%401.1.0` tag. Single-package projects are unaffected (the `v` prefix has nothing to encode); the first monorepo release is also unaffected (no compare link yet).

## The fix

Tags extracted from the compare link are decoded with `decodeURIComponent` (falling back to the raw value on malformed input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)