### PR TITLE
fix(core,pnpm,npm): resolve default publish tag from packages of independent monorepo

### DIFF
--- a/packages/core/src/project/monorepo.ts
+++ b/packages/core/src/project/monorepo.ts
@@ -202,6 +202,47 @@ export abstract class MonorepoProject extends Project {
     return this.getIndependentReleaseData(options)
   }
 
+  private async getIndependentDefaultPublishTag(options: ProjectReleaseOptions) {
+    for await (const project of this.getProjects()) {
+      const { manifest } = project
+
+      if (await manifest.isPrivate()) {
+        continue
+      }
+
+      const name = await manifest.getName()
+      const scope = await this.getScope(name)
+      const tagPrefix = await this.getTagPrefix(scope)
+      const tag = await project.getDefaultPublishTag({
+        ...options,
+        tagPrefix
+      })
+
+      if (tag) {
+        return tag
+      }
+    }
+
+    return undefined
+  }
+
+  /**
+   * Get the default publish tag for the monorepo.
+   * In independent mode it is resolved from the packages with their own tag prefixes —
+   * the first non-latest package defines the tag.
+   * @param options - The options to use for detecting tags.
+   * @returns The default publish tag, `undefined` for the latest release.
+   */
+  override async getDefaultPublishTag(options: ProjectReleaseOptions = {}): Promise<string | undefined> {
+    const { mode } = this
+
+    if (mode === 'fixed') {
+      return super.getDefaultPublishTag(options)
+    }
+
+    return this.getIndependentDefaultPublishTag(options)
+  }
+
   private async getIndependentMaintenanceBranches(options: ProjectMaintenanceBranchesOptions) {
     const branches: ProjectMaintenanceBranch[] = []
 

--- a/packages/core/src/project/packageJsonMonorepo.spec.ts
+++ b/packages/core/src/project/packageJsonMonorepo.spec.ts
@@ -9,7 +9,8 @@ import fg from 'fast-glob'
 import {
   packageJsonIndependentMonorepoProject,
   packageJsonFixedMonorepoProject,
-  forkProject
+  forkProject,
+  dummyCommit
 } from 'test'
 import type { GetProjectsOptions } from './monorepo.js'
 import type { Project } from './project.js'
@@ -245,6 +246,36 @@ describe('core', () => {
 - subproject-2@2.1.0
 - subproject-3@2.1.0`)
         })
+
+        it('should get no default publish tag for latest releases', async () => {
+          const { cwd } = await packageJsonIndependentMonorepoProject()
+          const project = new PackageJsonMonorepoProject({
+            mode: 'independent',
+            root: cwd,
+            getProjects
+          })
+
+          expect(await project.getDefaultPublishTag()).toBe(undefined)
+        })
+
+        it('should get default publish tag for maintenance release', async () => {
+          const { cwd, run } = await forkProject('independent-maintenance-publish-tag', packageJsonIndependentMonorepoProject())
+          const project = new PackageJsonMonorepoProject({
+            mode: 'independent',
+            root: cwd,
+            getProjects
+          })
+
+          await run([
+            ({ git }) => git.exec('checkout', '-b', 'next-major'),
+            ctx => dummyCommit(ctx, 'feat'),
+            ({ git }) => git.exec('tag', 'subproject-1@3.0.0'),
+            ({ git }) => git.exec('checkout', 'master'),
+            ({ git }) => git.exec('branch', '-D', 'next-major')
+          ])
+
+          expect(await project.getDefaultPublishTag()).toBe('release-2.x')
+        })
       })
 
       describe('fixed mode', () => {
@@ -338,6 +369,25 @@ describe('core', () => {
               isLatest: true
             }
           ])
+        })
+
+        it('should get default publish tag for maintenance release', async () => {
+          const { cwd, run } = await forkProject('fixed-maintenance-publish-tag', packageJsonFixedMonorepoProject())
+          const project = new PackageJsonMonorepoProject({
+            mode: 'fixed',
+            root: cwd,
+            getProjects
+          })
+
+          await run([
+            ({ git }) => git.exec('checkout', '-b', 'next-major'),
+            ctx => dummyCommit(ctx, 'feat'),
+            ({ git }) => git.exec('tag', 'v3.0.0'),
+            ({ git }) => git.exec('checkout', 'master'),
+            ({ git }) => git.exec('branch', '-D', 'next-major')
+          ])
+
+          expect(await project.getDefaultPublishTag()).toBe('release-2.x')
         })
 
         it('should get maintenance branch refs', async () => {

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -223,6 +223,34 @@ export abstract class Project {
   }
 
   /**
+   * Get the default publish tag for the project.
+   * Prerelease versions get their prerelease identifier,
+   * maintenance versions of previous majors get the `release-N.x` tag.
+   * @param options - The options to use for detecting tags.
+   * @returns The default publish tag, `undefined` for the latest release.
+   */
+  async getDefaultPublishTag(options: ProjectReleaseOptions = {}): Promise<string | undefined> {
+    const { manifest } = this
+    const prerelease = await manifest.getPrereleaseVersion()
+
+    if (prerelease) {
+      const [identifier] = prerelease
+
+      return typeof identifier === 'string'
+        ? identifier
+        : 'next'
+    }
+
+    if (!await this.isLatestRelease(options)) {
+      const version = await manifest.getVersion()
+
+      return `release-${semver.major(version)}.x`
+    }
+
+    return undefined
+  }
+
+  /**
    * Get maintenance branch refs to create after a major version release.
    * @param options - The options to use for detecting tags and formatting branches.
    * @returns Maintenance branch refs.

--- a/packages/core/src/releaser.ts
+++ b/packages/core/src/releaser.ts
@@ -1,5 +1,4 @@
 import type { ConventionalGitClient } from '@conventional-changelog/git-client'
-import semver from 'semver'
 import type { Project } from './project/index.js'
 import type { GitRepositoryHosting } from './hosting/index.js'
 import type {
@@ -522,38 +521,14 @@ export class Releaser<
       }
 
       // Maintenance and prerelease versions should not get the default `latest` npm tag.
-      publishOptions.tag ||= await this.getDefaultPublishTag()
+      publishOptions.tag ||= await project.getDefaultPublishTag({
+        tagPrefix: this.stepsOptions.bump?.tagPrefix
+      })
 
       logger.info('Publishing...')
 
       await project.publish(publishOptions)
     })
-  }
-
-  private async getDefaultPublishTag() {
-    const { project } = this
-    const { manifest } = project
-    const prerelease = await manifest.getPrereleaseVersion()
-
-    if (prerelease) {
-      const [identifier] = prerelease
-
-      return typeof identifier === 'string'
-        ? identifier
-        : 'next'
-    }
-
-    const isLatestRelease = await project.isLatestRelease({
-      tagPrefix: this.stepsOptions.bump?.tagPrefix
-    })
-
-    if (!isLatestRelease) {
-      const version = await manifest.getVersion()
-
-      return `release-${semver.major(version)}.x`
-    }
-
-    return undefined
   }
 
   /**

--- a/packages/npm/src/publish.ts
+++ b/packages/npm/src/publish.ts
@@ -30,17 +30,20 @@ export async function publish(project: PackageJsonProject, options: PublishOptio
       await manifest.getPrereleaseVersion()
     )
     : tag
+  const args = [
+    'publish',
+    ...access ? ['--access', access] : [],
+    ...publishTag ? ['--tag', publishTag] : [],
+    ...workspaces ? ['--workspaces'] : [],
+    ...dryRun ? ['--dry-run'] : [],
+    ...otp ? ['--otp', otp] : []
+  ]
+
+  logger?.verbose(`Publishing with command: npm ${args.join(' ')}`)
 
   await throwProcessError(spawn(
     'npm',
-    [
-      'publish',
-      ...access ? ['--access', access] : [],
-      ...publishTag ? ['--tag', publishTag] : [],
-      ...workspaces ? ['--workspaces'] : [],
-      ...dryRun ? ['--dry-run'] : [],
-      ...otp ? ['--otp', otp] : []
-    ],
+    args,
     {
       cwd: manifest.projectPath,
       env,

--- a/packages/pnpm/src/publish.ts
+++ b/packages/pnpm/src/publish.ts
@@ -31,18 +31,21 @@ export async function publish(project: PackageJsonProject, options: PublishOptio
       await manifest.getPrereleaseVersion()
     )
     : tag
+  const args = [
+    'publish',
+    ...access ? ['--access', access] : [],
+    ...publishTag ? ['--tag', publishTag] : [],
+    ...workspaces ? ['--recursive'] : [],
+    ...dryRun ? ['--dry-run'] : [],
+    ...otp ? ['--otp', otp] : [],
+    ...gitChecks ? [] : ['--no-git-checks']
+  ]
+
+  logger?.verbose(`Publishing with command: pnpm ${args.join(' ')}`)
 
   await throwProcessError(spawn(
     'pnpm',
-    [
-      'publish',
-      ...access ? ['--access', access] : [],
-      ...publishTag ? ['--tag', publishTag] : [],
-      ...workspaces ? ['--recursive'] : [],
-      ...dryRun ? ['--dry-run'] : [],
-      ...otp ? ['--otp', otp] : [],
-      ...gitChecks ? [] : ['--no-git-checks']
-    ],
+    args,
     {
       cwd: manifest.projectPath,
       env,


### PR DESCRIPTION
## The problem

The default publish tag was computed by the releaser from the **root** project. For independent monorepos the root manifest version (`0.0.0`) and the default `v` tag prefix match nothing, so `isLatestRelease` always returned `true` — maintenance releases were published to the `latest` npm tag. Reproduced in real conditions: https://github.com/TrigenSoftware/dummy-independent-monorepo/actions/runs/28820917537 — `foo@1.1.1` released from the `dummy-independent-monorepo-foo@1` maintenance branch hijacked `latest` from `2.0.0`. Fixed monorepos and GitHub releases were not affected (the root version is meaningful there, and `make_latest` is computed per package).

## The fix

- **core**: the default publish tag computation moved from the releaser to `Project#getDefaultPublishTag(options)`. In independent mode the monorepo resolves it from the packages, each with its own tag prefix — the first non-latest package defines the tag for the whole recursive publish; fixed mode keeps the root-based resolution. One release run belongs to one branch/release line, so a single tag per run is semantically correct — pnpm supports only one `--tag` per invocation anyway (the request body is built as `{ [opts.tag ?? 'latest']: version }`, `publishConfig.tag` is not read).
- **pnpm, npm**: the publish command with resolved parameters is logged in verbose mode.

Covered by specs: default publish tag for latest and maintenance releases in both monorepo modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)