### PR TITLE
fix(core): make `as: prerelease` produce a prerelease on stable versions

### DIFF
--- a/packages/core/src/project/packageJson.spec.ts
+++ b/packages/core/src/project/packageJson.spec.ts
@@ -182,6 +182,61 @@ describe('core', () => {
         expect(version).toBe('2.1.0-alpha.0')
       })
 
+      it('should get next prerelease version with forced prerelease type', async () => {
+        const { cwd } = await packageJsonProject()
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+        const version = await project.getNextVersion({
+          as: 'prerelease',
+          prerelease: 'alpha'
+        })
+
+        expect(version).toBe('2.1.0-alpha.0')
+      })
+
+      it('should get next prerelease version with forced prerelease type without identifier', async () => {
+        const { cwd } = await packageJsonProject()
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+        const version = await project.getNextVersion({
+          as: 'prerelease'
+        })
+
+        expect(version).toBe('2.1.0-0')
+      })
+
+      it('should get next prerelease version with forced prerelease type without new commits', async () => {
+        const { cwd } = await packageJsonProject({}, {
+          postReleaseCommits: false
+        })
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+        const version = await project.getNextVersion({
+          as: 'prerelease',
+          prerelease: 'alpha'
+        })
+
+        expect(version).toBe('2.0.1-alpha.0')
+      })
+
+      it('should advance prerelease version with forced prerelease type', async () => {
+        const { cwd } = await packageJsonProject({
+          version: '2.1.0-alpha.0'
+        })
+        const project = new PackageJsonProject({
+          path: join(cwd, 'package.json')
+        })
+        const version = await project.getNextVersion({
+          as: 'prerelease',
+          prerelease: 'alpha'
+        })
+
+        expect(version).toBe('2.1.0-alpha.1')
+      })
+
       it('should get next snapshot version from commits', async () => {
         const { cwd } = await packageJsonProject()
         const project = new PackageJsonProject({

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -339,9 +339,11 @@ export abstract class Project {
       return setSnapshotIdentifier(version, snapshot)
     }
 
+    // A forced prerelease keeps the release type derived from the commits.
+    const forcePrerelease = as === 'prerelease'
     let releaseType: ReleaseType | null = null
 
-    if (as) {
+    if (as && !forcePrerelease) {
       releaseType = as
     } else {
       const bump = await new Bumper(gitClient)
@@ -360,16 +362,19 @@ export abstract class Project {
     }
 
     if (!releaseType) {
-      if (!snapshot) {
+      if (!snapshot && !forcePrerelease) {
         return null
       }
 
-      // Snapshot versions always should be released, even without new commits.
+      // Snapshot and forced prerelease versions always should be released, even without new commits.
       releaseType = 'patch'
     }
 
     const prereleaseIdentifier = getPrereleaseIdentifier(
-      prerelease,
+      // A forced prerelease without an identifier still has to become a prerelease.
+      forcePrerelease
+        ? prerelease || ''
+        : prerelease,
       snapshot
     )
     const nextVersion = semver.inc(

--- a/packages/core/src/project/project.types.ts
+++ b/packages/core/src/project/project.types.ts
@@ -46,6 +46,8 @@ export interface ProjectBumpOptions {
   /**
    * The type of release to bump to.
    * If not provided, the version will be determined based on the commits.
+   * `prerelease` keeps the type determined based on the commits (patch if there are none)
+   * and makes the version a prerelease.
    */
   as?: ReleaseType
   /**

--- a/skills/simple-release-action/SKILL.md
+++ b/skills/simple-release-action/SKILL.md
@@ -152,7 +152,7 @@ The command line, then a fenced `json` block with releaser step options — the 
 | Option | Effect |
 | --- | --- |
 | `version` | Exact version, e.g. `"3.0.0"`. Overrides everything else. |
-| `as` | Release type: `major`, `minor`, `patch`, or `prerelease`. |
+| `as` | Release type: `major`, `minor`, `patch`, or `prerelease`. The last one keeps the type derived from the commits (a patch when there are none) and makes the version a prerelease. |
 | `prerelease` | Pre-release identifier, e.g. `"alpha"`. |
 | `byProject` | Per-package options in monorepos, keyed by full package name: `version`, `as`, `prerelease`, `firstRelease`, `skip`, `preamble`. |
 | `firstRelease` | Release the current manifest version as is, as if no release existed yet. |
@@ -167,11 +167,12 @@ Recipes for a pull request that proposes `1.2.0` on top of the released `1.1.0`:
 | `{"bump": {"version": "3.0.0"}}` | `3.0.0` |
 | `{"bump": {"prerelease": "alpha"}}` | `1.2.0-alpha.0` — the release type still comes from the commits |
 | `{"bump": {"as": "major", "prerelease": "alpha"}}` | `2.0.0-alpha.0` |
+| `{"bump": {"as": "prerelease", "prerelease": "alpha"}}` | `1.2.0-alpha.0` — like the identifier alone, but released even without new commits (`1.1.1-alpha.0` then) |
 | `{"bump": {"byProject": {"@org/pkg-a": {"as": "minor"}, "@org/pkg-b": {"skip": true}}}}` | Independent monorepo: `pkg-a` gets a minor, `pkg-b` is held back, the rest follow their commits |
 
 Prerelease lines: once `1.2.0-alpha.0` is released, the next pull request is computed from the commits after that tag. With `prerelease: "alpha"` again it becomes `1.2.0-alpha.1`, without it `1.2.0` (graduation), with `prerelease: "beta"` `1.2.0-beta.0`, and a breaking change moves it to `2.0.0-alpha.0`. To graduate when no releasable commits landed since the last prerelease, force the type: `{"bump": {"as": "patch"}}` gives `1.2.0`.
 
-Do not combine `as: "prerelease"` with a `prerelease` identifier on a stable version — the version resolution yields nothing and no pull request is produced. Start a line with the identifier alone or with `as` set to `major`, `minor`, or `patch`; `as: "prerelease"` is for advancing an existing prerelease.
+Older action versions produced no pull request for `as: "prerelease"` with an identifier on a stable version. If that happens, start the line with the identifier alone or with `as` set to `major`, `minor`, or `patch`.
 
 ### `!simple-release/set-preamble`
 
@@ -220,7 +221,7 @@ gh run watch <run-id>
 | Input | Effect |
 | --- | --- |
 | `version` | Exact version. Overrides everything else. |
-| `as` | Release type: `major`, `minor`, `patch`, or `prerelease`. |
+| `as` | Release type: `major`, `minor`, `patch`, or `prerelease`. The last one keeps the type derived from the commits (a patch when there are none) and makes the version a prerelease. |
 | `prerelease` | Pre-release identifier — `as=minor` with `prerelease=beta` on `1.0.0` gives `1.1.0-beta.0`. |
 | `by-project` | JSON keyed by full package names with per-package `version`, `as`, `prerelease`, and `skip`. |
 
@@ -230,7 +231,7 @@ Notes:
 - With no releasable commits since the last release, `as` produces a "Version bump without any changes." release — the way to cut a version on a schedule.
 - A dispatch with no inputs just re-runs the pull request flow for the branch head — a way to regenerate the pull request after a config change without pushing anything.
 - `--ref` picks the branch: the default branch when omitted, a maintenance branch such as `v1` to force a release there.
-- The prerelease caveat applies here too: `as=prerelease` together with `prerelease=<id>` on a stable version produces nothing.
+- The same caveat as for comments: older action versions produced nothing for `as=prerelease` with an identifier on a stable version — use `as=minor` (or `patch`, `major`) with the identifier there.
 
 ## Snapshot from Any Branch
 
@@ -293,7 +294,7 @@ gh api repos/{owner}/{repo}/actions/permissions/workflow
 | | The run happened but the options were not applied: invalid JSON, no `json` fence, or the author is not an owner, member, or collaborator | Fix and post again; with `releaser.verbose` the log says "Failed to parse parameters comment" for invalid JSON |
 | | The comment was edited — edits do not trigger runs | Post a new comment, or delete and re-post |
 | `gh workflow run` fails | "Workflow does not have 'workflow_dispatch' trigger", or unexpected inputs | The manual release or snapshot add-on is not set up — offer the setup skill |
-| Prerelease produced no pull request | `as: prerelease` with an identifier on a stable version | Use the identifier alone, or with `as` set to `major`, `minor`, or `patch` |
+| Prerelease produced no pull request | An older action version: `as: prerelease` with an identifier on a stable version used to yield nothing | Update simple-release-action, or use the identifier alone or with `as` set to `major`, `minor`, or `patch` |
 | Renovate or Dependabot commits do not release a monorepo package | The `deps` scope is not a package name | `bump.extraScopes: ["deps"]` in the config |
 | Fixed monorepo: unchanged packages kept their version | By design — only changed packages are bumped | `bump.force: true` in the config |
 

--- a/website/src/content/docs/github-action/manual-release.mdx
+++ b/website/src/content/docs/github-action/manual-release.mdx
@@ -66,8 +66,8 @@ For example, dispatching `as=minor` on a repository released as `1.0.0` with no 
 | Input | Effect |
 | --- | --- |
 | `version` | Sets the exact version, e.g. `3.1.0`. Overrides everything else. |
-| `as` | Forces the release type: `major`, `minor`, `patch`, or `prerelease`. |
-| `prerelease` | Pre-release identifier — combine with `as: prerelease` to get `1.1.0-alpha.0`. |
+| `as` | Forces the release type: `major`, `minor`, `patch`, or `prerelease`. The last one keeps the type derived from the commits — a patch when there are none — and makes the version a prerelease. |
+| `prerelease` | Pre-release identifier. `as=prerelease` with `prerelease=alpha` on `1.0.0` with a `feat` commit gives `1.1.0-alpha.0`; `as=minor` with the same identifier forces the minor regardless of the commits. |
 
 ## Per-package bumps in monorepos
 

--- a/website/src/content/docs/js-api/releaser.mdx
+++ b/website/src/content/docs/js-api/releaser.mdx
@@ -76,7 +76,7 @@ releaser
 | Option | Description |
 | --- | --- |
 | `version` | Force a specific version. |
-| `as` | Force a release type: `major`, `minor`, `patch`, or `prerelease`. |
+| `as` | Force a release type: `major`, `minor`, `patch`, or `prerelease`. The last one keeps the type derived from the commits — a patch when there are none — and makes the version a prerelease. |
 | `prerelease` | Pre-release identifier for prerelease bumps. |
 | `snapshot` | Pre-release identifier with a timestamp suffix for [snapshot builds](/github-action/snapshot-release/). Always applied when set. |
 | `skipChangelog` | Update versions without generating the changelog. |


### PR DESCRIPTION
## Summary

`as: 'prerelease'` combined with a prerelease identifier resolved to the non-existent semver increment `preprerelease` on a stable version, so `getNextVersion` returned `null` and no release pull request was produced. The docs promised `1.1.0-alpha.0` for that combination, and the dispatch form offers `prerelease` right next to the identifier field.

Now `as: 'prerelease'` keeps the release type derived from the commits (a patch when there are none, like other forced types) and makes the version a prerelease, with or without an identifier:

| Version | Commits since tag | Options | Result |
| --- | --- | --- | --- |
| `2.0.0` | feat, fix | `as: prerelease`, `prerelease: alpha` | `2.1.0-alpha.0` |
| `2.0.0` | feat, fix | `as: prerelease` | `2.1.0-0` |
| `2.0.0` | none | `as: prerelease`, `prerelease: alpha` | `2.0.1-alpha.0` |
| `2.1.0-alpha.0` | feat, fix | `as: prerelease`, `prerelease: alpha` | `2.1.0-alpha.1` |

Behavior change to note: `as: prerelease` without an identifier on a stable version used to be a plain semver prerelease increment (`2.0.0` → `2.0.1-0`); it now follows the commits (`2.1.0-0`).

The `manual-release` and `releaser` docs pages and the `simple-release-action` skill describe the resulting behavior.

## Test plan

- [x] 4 new `getNextVersion` cases in `packageJson.spec.ts`
- [x] `pnpm --filter @simple-release/core test` (lint, unit, types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
