### PR TITLE
fix(github): drop publish options and fix preamble heading level in the pull request cheatsheet

### DIFF
--- a/packages/github/src/cheatsheet.ts
+++ b/packages/github/src/cheatsheet.ts
@@ -9,32 +9,23 @@ You can configure the bot's behavior through a pull request comment using the \`
 
 \`\`\`json
 {
-  "bump": {},
-  "publish": {}
+  "bump": {}
 }
 \`\`\`
 \`\`\`\`
 
 ### Useful Parameters
 
-#### Bump
+The options shape the pull request generation, so the \`bump\` ones matter here. Release-time options like \`publish\` belong in the config file.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | \`version\` | \`string\` | Force set specific version |
-| \`as\` | \`'major' \\| 'minor' \\| 'patch' \\| 'prerelease'\` | Release type |
+| \`as\` | \`'major' \\| 'minor' \\| 'patch' \\| 'prerelease'\` | Release type. \`prerelease\` keeps the type derived from the commits and makes the version a prerelease |
 | \`prerelease\` | \`string\` | Pre-release identifier (e.g., "alpha", "beta") |
 | \`firstRelease\` | \`boolean\` | Whether this is the first release |
 | \`skip\` | \`boolean\` | Skip version bump |
 | \`byProject\` | \`Record<string, object>\` | Per-project bump options for monorepos |
-
-#### Publish
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| \`skip\` | \`boolean\` | Skip publishing |
-| \`access\` | \`'public' \\| 'restricted'\` | Package access level |
-| \`tag\` | \`string\` | Tag for npm publication |
 
 ### Usage Examples
 
@@ -80,32 +71,14 @@ You can configure the bot's behavior through a pull request comment using the \`
 \`\`\`
 \`\`\`\`
 
-#### Publish with specific access and tag
-
-\`\`\`\`md
-!simple-release/set-options
-
-\`\`\`json
-{
-  "bump": {
-    "prerelease": "beta"
-  },
-  "publish": {
-    "access": "public",
-    "tag": "beta"
-  }
-}
-\`\`\`
-\`\`\`\`
-
 ### Custom Changelog Preamble
 
-You can add custom markdown to the top of the changelog (right after the version header) using the \`!simple-release/set-preamble\` command. The markdown after the command line becomes the preamble.
+You can add custom markdown to the top of the changelog (right after the version header) using the \`!simple-release/set-preamble\` command. The markdown after the command line becomes the preamble. Start its headings at \`###\` — the level of the generated changelog sections like \`### Features\`.
 
 \`\`\`md
 !simple-release/set-preamble
 
-## What's new?
+### What's new?
 
 - The website was completely redesigned
 - The new API gives you awesome possibilities
@@ -116,7 +89,7 @@ In a monorepo, pass the full package name after the command to target a single p
 \`\`\`md
 !simple-release/set-preamble \`@your-org/core\`
 
-## Core changes
+### Core changes
 
 - New plugin system
 \`\`\`

--- a/website/src/content/docs/github-action/release-automation.mdx
+++ b/website/src/content/docs/github-action/release-automation.mdx
@@ -143,12 +143,12 @@ To force a version or release type without leaving the terminal, there is also a
 
 ### Custom changelog preamble
 
-A second command, `!simple-release/set-preamble`, adds custom markdown to the top of the changelog — right after the version header, before the generated sections. The markdown after the command line becomes the preamble, perfect for a "What's new?" summary:
+A second command, `!simple-release/set-preamble`, adds custom markdown to the top of the changelog — right after the version header, before the generated sections. The markdown after the command line becomes the preamble, perfect for a "What's new?" summary. Start its headings at `###` — the version header is `##` and the generated sections like `### Features` are `###`, so the preamble reads as one of them:
 
 ````md
 !simple-release/set-preamble
 
-## What's new?
+### What's new?
 
 - The website was completely redesigned
 - The new API gives you awesome possibilities
@@ -159,7 +159,7 @@ In a monorepo, pass the full package name after the command to target one packag
 ````md
 !simple-release/set-preamble `@your-org/core`
 
-## Core changes
+### Core changes
 
 - New plugin system
 ````


### PR DESCRIPTION
## Summary

Comment options are read by the pull request flow only (`fetchOptions` in `runPullRequestAction`); the release job runs on the merged commit and never reads comments. The cheatsheet in every release pull request body still advertised `publish` parameters and a "publish with specific access and tag" example, which never took effect. It now lists the `bump` options and says where release-time options belong.

The `set-preamble` examples in the cheatsheet and on the release automation docs page started at `##`, the level of the version header. A preamble belongs at `###`, the level of the generated sections (`### Features`), as in TrigenSoftware/nano_kit#186. Both places now say so and use `###`.

No behavior change.

## Test plan

- [x] `pnpm --filter @simple-release/github test` (lint, unit, types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
