### PR TITLE
ci: publish through npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,10 @@ jobs:
     name: Release
     needs: check
     if: needs.check.outputs.continue == 'true'
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
@@ -67,13 +71,11 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: pnpm install
       - name: Simple release
         run: pnpm tsm --no-warnings ./packages/ci/src/action.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Switches the release job from the `NPM_TOKEN` secret to npm [trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC), the same setup as in nano_kit, Argue, and nanoviews:

- `permissions` on the `release` job: `contents: write`, `pull-requests: write` (what the pull request and release flows already use through the default write permissions), plus `id-token: write` for the OIDC token.
- `actions/setup-node`: Node.js 24, which ships npm 11.5.1+ — the minimum for trusted publishing; `registry-url` dropped, there is no token to write into `.npmrc`.
- `NODE_AUTH_TOKEN` env dropped from the release step.

`pnpm publish --recursive` delegates to npm, so nothing changes in `packages/ci`. All eight published packages have `repository.url` pointing at this repository, and `clean-publish` keeps the field, so the automatic provenance check passes.

## Before merging the next release pull request

Register the trusted publisher for every published package on npmjs.com — repository `TrigenSoftware/simple-release`, workflow filename `release.yml` — either in each package's **Settings → Trusted Publisher → GitHub Actions**, or with the npm CLI (11.15+, two-factor authentication):

```sh
for pkg in @simple-release/config @simple-release/core @simple-release/github @simple-release/github-action @simple-release/node-gha @simple-release/npm @simple-release/pnpm simple-github-release; do
  npx npm@latest trust github "$pkg" --repository TrigenSoftware/simple-release --file release.yml --allow-publish --yes
  sleep 2
done
```

Without the registrations the publish step of the next release fails with `ENEEDAUTH` after the tag is created. Once a release has gone through, the `NPM_TOKEN` secret and the token itself can be removed.

## Test plan

- [x] YAML parses; the diff is limited to the `release` job
- [ ] Trusted publishers registered on npmjs.com for the eight packages
- [ ] Release pull request #196 merged after this: the publish step logs `npm notice publish Signed provenance statement ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
